### PR TITLE
Add status validation to node registry contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A decentralized IoT node management system built on Stacks blockchain.
 ## Overview
 LoopNode enables decentralized registration and management of IoT nodes with the following features:
 - Node registration with metadata
-- Node status tracking
+- Node status tracking with validation
 - Data reporting capabilities
 - Node authorization management
 - Audit trail of node activities
 
 ## Contracts
-- `node-registry.clar`: Main contract for node registration and management
+- `node-registry.clar`: Main contract for node registration and management. Includes status validation with predefined valid states: "active", "inactive", "maintenance", "retired"
 - `node-data.clar`: Contract handling node data submissions and history
 - `node-auth.clar`: Contract managing node authorization and access control
 

--- a/contracts/node-registry.clar
+++ b/contracts/node-registry.clar
@@ -4,13 +4,17 @@
 (define-constant contract-owner tx-sender)
 (define-constant err-not-authorized (err u100))
 (define-constant err-already-registered (err u101))
+(define-constant err-invalid-status (err u102))
+
+;; Valid status values
+(define-constant valid-statuses (list "active" "inactive" "maintenance" "retired"))
 
 ;; Data structures
 (define-map nodes
   { node-id: (string-ascii 64) }
   {
     owner: principal,
-    metadata: (string-utf8 256),
+    metadata: (string-utf8 256), 
     status: (string-ascii 20),
     registered-at: uint
   }
@@ -42,6 +46,7 @@
 )
   (let ((node (unwrap! (get-node-info node-id) err-not-authorized)))
     (asserts! (is-eq (get owner node) tx-sender) err-not-authorized)
+    (asserts! (is-some (index-of valid-statuses new-status)) err-invalid-status)
     (ok (map-set nodes
       { node-id: node-id }
       (merge node { status: new-status })
@@ -52,4 +57,8 @@
 ;; Read only functions
 (define-read-only (get-node-info (node-id (string-ascii 64)))
   (map-get? nodes { node-id: node-id })
+)
+
+(define-read-only (get-valid-statuses)
+  valid-statuses
 )

--- a/tests/node-registry_test.ts
+++ b/tests/node-registry_test.ts
@@ -30,3 +30,33 @@ Clarinet.test({
     block.receipts[0].result.expectOk().expectBool(true);
   },
 });
+
+Clarinet.test({
+  name: "Ensures status update with invalid status fails",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    const wallet_1 = accounts.get("wallet_1")!;
+    
+    let block = chain.mineBlock([
+      Tx.contractCall(
+        "node-registry", 
+        "register-node",
+        [
+          types.ascii("node-001"),
+          types.utf8("test node metadata")
+        ],
+        wallet_1.address
+      ),
+      Tx.contractCall(
+        "node-registry",
+        "update-status",
+        [
+          types.ascii("node-001"),
+          types.ascii("invalid")
+        ],
+        wallet_1.address
+      )
+    ]);
+    
+    block.receipts[1].result.expectErr(102);
+  },
+});


### PR DESCRIPTION
This PR enhances the node registry contract by adding status validation functionality.

Changes made:
- Added a list of valid node statuses: "active", "inactive", "maintenance", "retired"
- Added validation in the update-status function to ensure only valid statuses can be set
- Added a new error code (u102) for invalid status attempts
- Added a new read-only function to query valid statuses
- Added test cases to verify status validation
- Updated documentation to reflect these changes

Impact:
- Improves data consistency by preventing invalid status values
- Maintains backward compatibility while adding new validation
- Makes the contract more robust and maintainable

Testing:
- Added new test case specifically for invalid status validation
- Existing tests continue to pass
- Manually tested all status transitions